### PR TITLE
Liri changes on top of 0.27.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,8 +36,8 @@ jobs:
     strategy:
       matrix:
         arch: [ amd64 ]
-        os: [ windows-2019, macos-11 ]
-        tfm: [ net472, net6.0, net7.0 ]
+        os: [ macos-11 ]
+        tfm: [ net6.0, net7.0 ]
         exclude:
           - os: macos-11
             tfm: net472
@@ -61,19 +61,11 @@ jobs:
     strategy:
       matrix:
         arch: [ amd64 ]
-        # arch: [ amd64, arm64 ]
-        distro: [ alpine.3.13, alpine.3.14, alpine.3.15, alpine.3.16, alpine.3.17, centos.7, centos.stream.8, debian.10, debian.11, fedora.36, ubuntu.18.04, ubuntu.20.04, ubuntu.22.04 ]
-        sdk:  [ '6.0', '7.0' ]
-        exclude:
-          - distro: alpine.3.13
-            sdk: '7.0'
-          - distro: alpine.3.14
-            sdk: '7.0'
+        distro: [ alpine.3.18, debian.11 ]
+        sdk:  [ '6.0' ]
         include:
           - sdk: '6.0'
             tfm: net6.0
-          - sdk: '7.0'
-            tfm: net7.0
       fail-fast: false
     steps:
       - name: Checkout

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ _ReSharper*/
 _NCrunch_LibGit2Sharp/
 packages/
 worktree.playlist
+.idea/

--- a/LibGit2Sharp.Tests/LibGit2Sharp.Tests.csproj
+++ b/LibGit2Sharp.Tests/LibGit2Sharp.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks Condition="'$(TargetFrameworks)'==''">net472;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(TargetFrameworks)'==''">net6.0;net7.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/LibGit2Sharp.Tests/MetaFixture.cs
+++ b/LibGit2Sharp.Tests/MetaFixture.cs
@@ -164,7 +164,10 @@ namespace LibGit2Sharp.Tests
                 }
                 catch
                 {
-                    nonTestableTypes.Add(type, new List<string>());
+                    if (!nonTestableTypes.TryGetValue(type, out _))
+                    {
+                        nonTestableTypes.Add(type, new List<string>());
+                    }
                 }
             }
 

--- a/LibGit2Sharp.sln
+++ b/LibGit2Sharp.sln
@@ -12,10 +12,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		Targets\CodeGenerator.targets = Targets\CodeGenerator.targets
 		Directory.Build.props = Directory.Build.props
 		Targets\GenerateNativeDllName.targets = Targets\GenerateNativeDllName.targets
-		nuget.config = nuget.config
+		README.md = README.md
 	EndProjectSection
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NativeLibraryLoadTestApp.x86", "NativeLibraryLoadTestApp\x86\NativeLibraryLoadTestApp.x86.csproj", "{86453D2C-4953-4DF4-B12A-ADE579608BAA}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NativeLibraryLoadTestApp.x64", "NativeLibraryLoadTestApp\x64\NativeLibraryLoadTestApp.x64.csproj", "{5C55175D-6A1F-4C51-B791-BF7DD00124EE}"
 EndProject
@@ -33,10 +31,6 @@ Global
 		{286E63EB-04DD-4ADE-88D6-041B57800761}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{286E63EB-04DD-4ADE-88D6-041B57800761}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{286E63EB-04DD-4ADE-88D6-041B57800761}.Release|Any CPU.Build.0 = Release|Any CPU
-		{86453D2C-4953-4DF4-B12A-ADE579608BAA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{86453D2C-4953-4DF4-B12A-ADE579608BAA}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{86453D2C-4953-4DF4-B12A-ADE579608BAA}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{86453D2C-4953-4DF4-B12A-ADE579608BAA}.Release|Any CPU.Build.0 = Release|Any CPU
 		{5C55175D-6A1F-4C51-B791-BF7DD00124EE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{5C55175D-6A1F-4C51-B791-BF7DD00124EE}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{5C55175D-6A1F-4C51-B791-BF7DD00124EE}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/LibGit2Sharp/CyclicReferenceException.cs
+++ b/LibGit2Sharp/CyclicReferenceException.cs
@@ -1,0 +1,11 @@
+namespace LibGit2Sharp
+{
+    public class CyclicReferenceException : LibGit2SharpException
+    {
+        public CyclicReferenceException(string reference) : base($"Detected cyclic reference on '{reference}'")
+        {
+        }
+
+        protected CyclicReferenceException() {}
+    }
+}

--- a/LibGit2Sharp/LibGit2Sharp.csproj
+++ b/LibGit2Sharp/LibGit2Sharp.csproj
@@ -1,14 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;net6.0</TargetFrameworks>
+    <PackageId>Apiiro.LibGit2Sharp</PackageId>
+    <Authors>Apiiro</Authors>
+    <Company>Apiiro</Company>
+    <RepositoryUrl>https://github.com/apiiro/libgit2sharp</RepositoryUrl>
+    <TargetFramework>net6.0</TargetFramework>
+    <LangVersion>10.0</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Description>LibGit2Sharp brings all the might and speed of libgit2, a native Git implementation, to the managed world of .NET</Description>
-    <Company>LibGit2Sharp contributors</Company>
+    <PackageDescription>LibGit2Sharp brings all the might and speed of libgit2, a native Git implementation, to the managed world of .NET</PackageDescription>
     <Copyright>Copyright © LibGit2Sharp contributors</Copyright>
     <PackageTags>libgit2 git</PackageTags>
-    <PackageProjectUrl>https://github.com/libgit2/libgit2sharp/</PackageProjectUrl>
-    <Authors>LibGit2Sharp contributors</Authors>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <DebugType>embedded</DebugType>

--- a/LibGit2Sharp/Reference.cs
+++ b/LibGit2Sharp/Reference.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 using LibGit2Sharp.Core;
@@ -53,6 +54,11 @@ namespace LibGit2Sharp
             {
                 case GitReferenceType.Symbolic:
                     string targetIdentifier = Proxy.git_reference_symbolic_target(handle);
+
+                    if (name == targetIdentifier)
+                    {
+                        throw new CyclicReferenceException(name);
+                    }
 
                     var targetRef = repo.Refs[targetIdentifier];
                     reference = new SymbolicReference(repo, name, targetIdentifier, targetRef);

--- a/NativeLibraryLoadTestApp/x64/NativeLibraryLoadTestApp.x64.csproj
+++ b/NativeLibraryLoadTestApp/x64/NativeLibraryLoadTestApp.x64.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,18 @@
 # LibGit2Sharp
 
-[![CI](https://github.com/libgit2/libgit2sharp/actions/workflows/ci.yml/badge.svg)](https://github.com/libgit2/libgit2sharp/actions/workflows/ci.yml) 
+[![CI](https://github.com/libgit2/libgit2sharp/actions/workflows/ci.yml/badge.svg)](https://github.com/libgit2/libgit2sharp/actions/workflows/ci.yml)
 [![NuGet version (LibGit2Sharp)](https://img.shields.io/nuget/v/LibGit2Sharp.svg)](https://www.nuget.org/packages/LibGit2Sharp/)
 
 **LibGit2Sharp brings all the might and speed of [libgit2](http://libgit2.github.com/), a native Git implementation, to the managed world of .NET**
+
+To push to apiiro nuget package:
+
+```
+dotnet build --configuration Release
+rm bin/Packages/Apiiro.LibGit2Sharp.*.nupkg
+dotnet pack --configuration Release
+dotnet nuget push bin/Packages/Apiiro.LibGit2Sharp.*.nupkg --source "github" --skip-duplicate --no-symbols
+```
 
 ## Online resources
 


### PR DESCRIPTION
I forced pushed master to 0.27.2, It seems like this is the latest version that doesn't segfault.
This pr is adding Liri custom changes on top of that.
Published version [0.27.3-preview.0.1](https://github.com/orgs/apiiro/packages/nuget/Apiiro.LibGit2Sharp/183762128).